### PR TITLE
Add name of the system pip package into defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,19 @@ On RedHat/CentOS, you may need to have EPEL installed before running this role. 
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+The name of the packge to install to get `pip` on the system.
+
+    pip_package_name: python-pip
+
+For example:
+
+    pip_package_name: python3-pip
+
+A list of packages to install with pip.
+
     pip_install_packages: []
 
-A list of packages to install with pip. Examples below:
+Examples below:
 
     pip_install_packages:
       # Specify names and versions.
@@ -22,19 +32,19 @@ A list of packages to install with pip. Examples below:
         version: "1.2.3"
       - name: awscli
         version: "1.11.91"
-    
+
       # Or specify bare packages to get the latest release.
       - docker
       - awscli
-    
+
       # Or uninstall a package.
       - name: docker
         state: absent
-    
+
       # Or update a package ot the latest version.
       - name: docker
         state: latest
-    
+
       # Or force a reinstall.
       - name: docker
         state: forcereinstall

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+pip_package_name: python-pip
 pip_install_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Ensure Pip is installed.
-  package: name=python-pip state=present
+  package:
+    name: "{{pip_package_name}}"
+    state: present
 
 - name: Ensure pip_install_packages are installed.
   pip:


### PR DESCRIPTION
On Amazon Linux, installing `python-pip` acutally installs the `python26-pip` package, so anything running in Python 2.7 won't find the dependencies installed with that `pip`.

This allows the package name to be customised, depending on the OS and Python versions.

This change should address #6.