### PR TITLE
Add ability to use the role on CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The name of the packge to install to get `pip` on the system. You can set to `py
 
     pip_install_packages: []
 
+The role will try to autodetect pip executable: it will use `pip` for Python 2 and `pip3` for Python 3. You can also override this explicitly:
+
+    pip_executable: pip3.6
+
+
 A list of packages to install with pip. Examples below:
 
     pip_install_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # For Python 3, use python3-pip.
 pip_package: python-pip
-
+pip_executable: "{{ 'pip3' if pip_package.startswith('python3') else 'pip' }}"
 pip_install_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,5 +10,5 @@
     version: "{{ item.version | default(omit) }}"
     virtualenv: "{{ item.virtualenv | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
-    executable: "{{ 'pip3' if pip_package == 'python3-pip' else 'pip' }}"
+    executable: "{{ pip_executable }}"
   with_items: "{{ pip_install_packages }}"


### PR DESCRIPTION
Two improvements:

- Package for CentOS 7 is called python34-pip, therefore test on which pip executable to use was failing (fixed with using `pip_package.startswith('python3')`)
- For the case this is still not sufficient (i.e., you need more specific executable version, say, `pip3.6`), `pip_executable` moved to defaults and is can be overridden.