### PR TITLE
wait for yum lock

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Wait for yum lock to be cleared
+  wait_for:
+    path: /var/run/yum.pid
+    state: absent
+  when: ansible_os_family == 'RedHat'
+
 - name: Ensure Pip is installed.
   package:
     name: "{{ pip_package }}"


### PR DESCRIPTION
When running against Rhel servers sometimes `package` module tries to run before the yum lock has been cleared, causing the play to fail. This adds an explicit wait to prevent that from happening.