### PR TITLE
Added task to upgrade pip before installing other pip packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,5 @@
 pip_package: python-pip
 pip_executable: "{{ 'pip3' if pip_package.startswith('python3') else 'pip' }}"
 
+pip_upgrade: false
 pip_install_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,11 @@
     name: "{{ pip_package }}"
     state: present
 
-- name: Upgrade Pip
-  pip:
+- name: Upgrade Pip # noqa 403
+  pip: 
     name: pip
     state: latest
-  when: "{{ pip_upgrade }}"
+  when: pip_upgrade | bool
 
 - name: Ensure pip_install_packages are installed.
   pip:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,12 @@
     name: "{{ pip_package }}"
     state: present
 
+- name: Upgrade Pip
+  pip:
+    name: pip
+    state: latest
+  when: "{{ pip_upgrade }}"
+
 - name: Ensure pip_install_packages are installed.
   pip:
     name: "{{ item.name | default(item) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,8 @@
     name: "{{ pip_package }}"
     state: present
 
-- name: Upgrade Pip # noqa 403
-  pip: 
+- name: Upgrade Pip  # noqa 403
+  pip:
     name: pip
     state: latest
   when: pip_upgrade | bool


### PR DESCRIPTION
I was missing option to upgrade pip before installing packages.

Especially on Centos7 I had problems installing some packages because of old pip version.

I made this task disabled by default, because I think it should be used only if needed and enabled at runtime. 