### PR TITLE
Autodetect python used by ansible as default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # For Python 3, use python3-pip.
-pip_package: "{{ 'python-pip' if ansible_python_interpreter.endswith('python2') else 'python3-pip' }}"
+pip_package: "{{ 'python-pip' if (ansible_python_interpreter| default('python3')).endswith('python2') else 'python3-pip' }}"
 pip_executable: "{{ 'pip3' if pip_package.startswith('python3') else 'pip' }}"
 
 pip_install_packages: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # For Python 3, use python3-pip.
-pip_package: python-pip
+pip_package: "{{ 'python-pip' if ansible_python_interpreter.endswith('python2') else 'python3-pip' }}"
 pip_executable: "{{ 'pip3' if pip_package.startswith('python3') else 'pip' }}"
 
 pip_install_packages: []


### PR DESCRIPTION
Reasoning:
default to py3 as py2 is soon to go down and most should already use py3.

It does not work out of the box If you use py3 with other roles like this one:
https://github.com/geerlingguy/ansible-role-docker/blob/master/README.md

so either docs there needs this little line update OR this pr needs to go in.
to make it work for most people without any changes, this makes a lot of sense.
