### PR TITLE
Add possibility to pass extra arguments to pip command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ A list of packages to install with pip. Examples below:
         version: "1.2.3"
       - name: awscli
         version: "1.11.91"
-    
+
+      # Or pass extra arguments to the command
+      - name: setuptools
+        extra_args: "--upgrade"
+
       # Or specify bare packages to get the latest release.
       - docker
       - awscli

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,6 +10,9 @@
         version: "1.0.18"
       # Test installing a package by name.
       - colorama
+      # Test installing a package with extra arguments
+      - name: setuptools
+        extra_args: "--upgrade"
 
   pre_tasks:
     - name: Update apt cache.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Ensure pip_install_packages are installed.
   pip:
     name: "{{ item.name | default(item) }}"
+    extra_args: "{{ item.extra_args | default(omit) }}"
     version: "{{ item.version | default(omit) }}"
     virtualenv: "{{ item.virtualenv | default(omit) }}"
     state: "{{ item.state | default(omit) }}"


### PR DESCRIPTION
It is possible to do this in pip module already using: extra_args
![image](https://user-images.githubusercontent.com/22643870/76234718-5dcbb080-622a-11ea-92ac-af420734083a.png)
https://docs.ansible.com/ansible/latest/modules/pip_module.html#parameter-extra_args

With this change you can define these extra_args within the pip_install_packages item as shown in the README addition coming along with this PR.