### PR TITLE
Add support for centos8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - ROLE_NAME: pip
   matrix:
+    - MOLECULE_DISTRO: centos8
     - MOLECULE_DISTRO: centos7
     - MOLECULE_DISTRO: fedora29
     - MOLECULE_DISTRO: ubuntu1804

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,10 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
+    - name: CentOS
+      versions:
+        - 7
+        - 8
   galaxy_tags:
     - system
     - server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Gather OS specific variables.
+  include_vars: "{{ item }}"
+  with_first_found:
+      - "vars/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+      - "vars/{{ ansible_distribution }}.yml"
+      - "defaults/main.yml"
+
 - name: Ensure Pip is installed.
   package:
     name: "{{ pip_package }}"

--- a/vars/CentOS-8.yml
+++ b/vars/CentOS-8.yml
@@ -1,0 +1,2 @@
+---
+pip_package: python3-pip


### PR DESCRIPTION
The package naming for pip has changed in centos8. Previously the pip
package was called python-pip for python2 and python3-pip for python3.
In CentOS 8 the packages are now called python2-pip for python2 ad
python3-pip for python3.