### PR TITLE
Add update_cache to remove no matching packages error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   package:
     name: "{{ pip_package }}"
     state: present
+    update_cache: yes
 
 - name: Ensure pip_install_packages are installed.
   pip:


### PR DESCRIPTION
I have the following error when running this on a base Azure VM. 

`FAILED! => {"changed": false, "msg": "No package matching 'python3-pip' is available"}`

Adding this solved the issue.

Credits to https://github.com/sot528/ansible-role-pipenv/commit/dac1bb01779d5b069184addd95aa2c34a5f21ad4
