### PR TITLE
Allow umask parameter to pip module install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The name of the packge to install to get `pip` on the system. For older systems that don't have Python 3 available, you can set this to `python-pip`.
 
+    pip_umask: '0022' # Default is to omit the parameter
+
+The system umask to apply before installing the pip packages.
+
     pip_executable: pip3
 
 The role will try to autodetect the pip executable based on the `pip_package` (e.g. `pip` for Python 2 and `pip3` for Python 3). You can also override this explicitly, e.g. `pip_executable: pip3.6`.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,4 +11,5 @@
     virtualenv: "{{ item.virtualenv | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
     executable: "{{ pip_executable }}"
+    umask: "{{ pip_umask | default(omit) }}"
   with_items: "{{ pip_install_packages }}"


### PR DESCRIPTION
On systems with more restrictive umask defaults, not using a virtulenv with this role results in globally installed modules not usable (this occurred on CentOS 8 to me).

One solution for this would be to pass --user to the install. Currently, that is not possible (but there is PR #29 for that functionality!). 
Another solution is to pass a umask to the pip module as a parameter. This PR adds that ability via a variable, with documentation in README, and backwards compatibility maintained through defaulting to omitting it.
