### PR TITLE
Update apt cache

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Update apt cache
+  apt:
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
+
 - name: Ensure Pip is installed.
   package:
     name: "{{ pip_package }}"


### PR DESCRIPTION
Fixes geerlingguy/ansible-role-pip#37

Runs apt update on Debian systems. 

I'm not too sure how this issue got through Molecule tests although I would suggest [this line might have something to do with it.](https://github.com/geerlingguy/ansible-role-pip/runs/1496823823?check_suite_focus=true#step:5:104)