### PR TITLE
Migrating from with_X to loop

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,4 +11,4 @@
     virtualenv: "{{ item.virtualenv | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
     executable: "{{ pip_executable }}"
-  with_items: "{{ pip_install_packages }}"
+  loop: "{{ pip_install_packages }}"


### PR DESCRIPTION
Astonishingly, using `loop` instead of `with_items` fixes the deprecation warning. 

Fixes #36