### PR TITLE
Update Role to use the latest package from pip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Ensure Pip is installed.
   package:
     name: "{{ pip_package }}"
-    state: present
+    state: latest
 
 - name: Ensure pip_install_packages are installed.
   pip:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,14 @@
 - name: Ensure Pip is installed.
   package:
     name: "{{ pip_package }}"
-    state: latest
+    state: present
+
+- name: Upgrade pip
+  pip:
+    name: pip
+    state: present
+    executable: "{{ pip_executable }}"
+    extra_args: --upgrade
 
 - name: Ensure pip_install_packages are installed.
   pip:


### PR DESCRIPTION
during the installation from docker or docker-compose package via pip it vails because it is not the latest version  of pip
This pr fixes it. 

````
TASK [geerlingguy.pip : Ensure pip_install_packages are installed.] **********************************************************************************************************************************************************************************************************************************
changed: [localhost] => (item={'name': 'docker'})
failed: [localhost] (item={'name': 'docker-compose'}) => {"ansible_loop_var": "item", "changed": false, "cmd": ["/usr/bin/pip3", "install", "docker-compose"], "item": {"name": "docker-compose"}, "msg": "stdout: Collecting docker-compose\n  Downloading https://files.pythonhosted.org/packages/00/ff/17cdd2bc5f581cd80fc0b45b549d48c6eff7cd70d20a9f805a0c89394e69/docker_compose-1.28.4-py2.py3-none-any.whl (114kB)\nCollecting python-dotenv<1,>=0.13.0 (from docker-compose)\n  Downloading https://files.pythonhosted.org/packages/32/2e/e4585559237787966aad0f8fd0fc31df1c4c9eb0e62de458c5b6cde954eb/python_dotenv-0.15.0-py2.py3-none-any.whl\nCollecting dockerpty<1,>=0.4.1 (from docker-compose)\n  Downloading https://files.pythonhosted.org/packages/8d/ee/e9ecce4c32204a6738e0a5d5883d3413794d7498fe8b06f44becc028d3ba/dockerpty-0.4.1.tar.gz\nRequirement already satisfied: websocket-client<1,>=0.32.0 in /usr/local/lib/python3.6/site-packages (from docker-compose)\nRequirement already satisfied: PyYAML<6,>=3.10 in /usr/lib64/python3.6/site-packages (from docker-compose)\nCollecting texttable<2,>=0.9.0 (from docker-compose)\n  Downloading https://files.pythonhosted.org/packages/06/f5/46201c428aebe0eecfa83df66bf3e6caa29659dbac5a56ddfd83cae0d4a4/texttable-1.6.3-py2.py3-none-any.whl\nCollecting cached-property<2,>=1.2.0 (from docker-compose)\n  Downloading https://files.pythonhosted.org/packages/48/19/f2090f7dad41e225c7f2326e4cfe6fff49e57dedb5b53636c9551f86b069/cached_property-1.5.2-py2.py3-none-any.whl\nCollecting docopt<1,>=0.6.1 (from docker-compose)\n  Downloading https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz\nRequirement already satisfied: requests<3,>=2.20.0 in /usr/local/lib/python3.6/site-packages (from docker-compose)\nCollecting distro<2,>=1.5.0 (from docker-compose)\n  Downloading https://files.pythonhosted.org/packages/25/b7/b3c4270a11414cb22c6352ebc7a83aaa3712043be29daa05018fd5a5c956/distro-1.5.0-py2.py3-none-any.whl\nRequirement already satisfied: docker[ssh]<5,>=4.4.3 in /usr/local/lib/python3.6/site-packages (from docker-compose)\nCollecting jsonschema<4,>=2.5.1 (from docker-compose)\n  Downloading https://files.pythonhosted.org/packages/c5/8f/51e89ce52a085483359217bc72cdbf6e75ee595d5b1d4b5ade40c7e018b8/jsonschema-3.2.0-py2.py3-none-any.whl (56kB)\nRequirement already satisfied: six>=1.3.0 in /usr/lib/python3.6/site-packages (from dockerpty<1,>=0.4.1->docker-compose)\nRequirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/site-packages (from requests<3,>=2.20.0->docker-compose)\nRequirement already satisfied: chardet<5,>=3.0.2 in /usr/local/lib/python3.6/site-packages (from requests<3,>=2.20.0->docker-compose)\nRequirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.6/site-packages (from requests<3,>=2.20.0->docker-compose)\nRequirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/site-packages (from requests<3,>=2.20.0->docker-compose)\nCollecting paramiko>=2.4.2; extra == \"ssh\" (from docker[ssh]<5,>=4.4.3->docker-compose)\n  Downloading https://files.pythonhosted.org/packages/95/19/124e9287b43e6ff3ebb9cdea3e5e8e88475a873c05ccdf8b7e20d2c4201e/paramiko-2.7.2-py2.py3-none-any.whl (206kB)\nCollecting importlib-metadata; python_version < \"3.8\" (from jsonschema<4,>=2.5.1->docker-compose)\n  Downloading https://files.pythonhosted.org/packages/f3/ed/da40116a204abb5c4dd1d929346d33e0d29cedb2cedd18ea98f0385dcd92/importlib_metadata-3.4.0-py3-none-any.whl\nCollecting attrs>=17.4.0 (from jsonschema<4,>=2.5.1->docker-compose)\n  Downloading https://files.pythonhosted.org/packages/c3/aa/cb45262569fcc047bf070b5de61813724d6726db83259222cd7b4c79821a/attrs-20.3.0-py2.py3-none-any.whl (49kB)\nRequirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from jsonschema<4,>=2.5.1->docker-compose)\nCollecting pyrsistent>=0.14.0 (from jsonschema<4,>=2.5.1->docker-compose)\n  Downloading https://files.pythonhosted.org/packages/4d/70/fd441df751ba8b620e03fd2d2d9ca902103119616f0f6cc42e6405035062/pyrsistent-0.17.3.tar.gz (106kB)\nCollecting cryptography>=2.5 (from paramiko>=2.4.2; extra == \"ssh\"->docker[ssh]<5,>=4.4.3->docker-compose)\n  Downloading https://files.pythonhosted.org/packages/fa/2d/2154d8cb773064570f48ec0b60258a4522490fcb115a6c7c9423482ca993/cryptography-3.4.6.tar.gz (546kB)\n    Complete output from command python setup.py egg_info:\n    \n            =============================DEBUG ASSISTANCE==========================\n            If you are seeing an error here please try the following to\n            successfully install cryptography:\n    \n            Upgrade to the latest pip and try again. This will fix errors for most\n            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip\n            =============================DEBUG ASSISTANCE==========================\n    \n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/tmp/pip-build-erehz_5l/cryptography/setup.py\", line 14, in <module>\n        from setuptools_rust import RustExtension\n    ModuleNotFoundError: No module named 'setuptools_rust'\n    \n    ----------------------------------------\n\n:stderr: WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.\nCommand \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-erehz_5l/cryptography/\n"}
```