### PR TITLE
feat: add option for pip-envrionment-variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ A list of packages to install with pip. Examples below:
       - name: docker
         virtualenv: /my_app/venv
 
+To pass environment variables to `pip` use `pip_environment_variables`. (This is usefull for proxy configuration)
+
+```
+pip_environment_variables: 
+   http_proxy: "proxy.example.com"
+```
+
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,6 @@
 # For Python 3, use python3-pip.
 pip_package: python3-pip
 pip_executable: "{{ 'pip3' if pip_package.startswith('python3') else 'pip' }}"
+pip_environment_variables: []
 
 pip_install_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,4 @@
     state: "{{ item.state | default(omit) }}"
     executable: "{{ pip_executable }}"
   loop: "{{ pip_install_packages }}"
+  environment: "{{ pip_environment_variables }}"


### PR DESCRIPTION
This option is quite useful and needed when using an http(s) proxy.

ref: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html