### PR TITLE
Add support for extra_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ A list of packages to install with pip. Examples below:
       - name: docker
         virtualenv: /my_app/venv
 
+      # Or pass through any extra arguments.
+      - name: my_special_package_from_my_special_repo
+        extra_args: --extra-index-url https://my-domain/pypi/pypi-master/simple
+
 ## Dependencies
 
 None.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,5 +10,6 @@
     version: "{{ item.version | default(omit) }}"
     virtualenv: "{{ item.virtualenv | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
+    extra_args: "{{ item.extra_args | default(omit) }}"
     executable: "{{ pip_executable }}"
   loop: "{{ pip_install_packages }}"


### PR DESCRIPTION
'extra_args' has been available since 1.0 of ansible.builtin and this
module already uses 'executable' which was added in 1.3 so this should
be perfectly safe to add.