### PR TITLE
Draft: Adds Mac version to install pip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,15 @@
 ---
-- name: Ensure Pip is installed.
+- name: Ensure Pip is installed (linux)
   package:
     name: "{{ pip_package }}"
     state: present
+  when: ansible_facts["os_family"] != "Darwin"
+
+- name: Ensure Pip is installed (Mac)
+  package:
+    name: python
+    state: present
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Ensure pip_install_packages are installed.
   pip:


### PR DESCRIPTION
Hey Jeff,

Hope you're feeling well today given your recent troubles.

I've just discovered that this role does not support installing pip on Mac.  The description advises the role is only for linux, but wondered if you'd consider adding Mac support too?

My initial research indicates that installing the brew `python` package also includes `pip` so would this be an acceptable solution, so I've created this draft PR as a staring point for the discussion.  To be polished/tested/etc. if desired.