### PR TITLE
Add apt repository sync

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,5 @@ pip_package: python3-pip
 pip_executable: "{{ 'pip3' if pip_package.startswith('python3') else 'pip' }}"
 
 pip_install_packages: []
+
+pip_sync_repos: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,8 @@
 - name: Update APT repositories.
   ansible.builtin.apt:
     update_cache: yes
-  when: ansible_facts['os_family'] == "Debian"
+  when: ansible_facts['os_family'] == "Debian" and
+        pip_sync_repospip_sync_repos is true
 
 - name: Ensure Pip is installed.
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Update APT repositories.
+  ansible.builtin.apt:
+    update_cache: yes
+  when: ansible_facts['distribution'] == "Debian"
+
 - name: Ensure Pip is installed.
   package:
     name: "{{ pip_package }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.apt:
     update_cache: yes
   when: ansible_facts['os_family'] == "Debian" and
-        pip_sync_repospip_sync_repos is true
+        pip_sync_repos is true
 
 - name: Ensure Pip is installed.
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Update APT repositories.
   ansible.builtin.apt:
     update_cache: yes
-  when: ansible_facts['distribution'] == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Ensure Pip is installed.
   package:


### PR DESCRIPTION
If this role is ran against a fresh Debian based system it errors because the repos have not been synced so apt thinks the pip package does not exist. This fixes that by syncing the apt repos before we attempt to install pip on Debian based systems.

This is enabled by default but can be disabled by setting `pip_sync_repos` to false.