### PR TITLE
Upgrade pip to the latest version after we install it initially from the distro repos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,5 @@ pip_package: python3-pip
 pip_executable: "{{ 'pip3' if pip_package.startswith('python3') else 'pip' }}"
 
 pip_install_packages: []
+
+pip_sync_repos: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,18 @@
         pip_sync_repos is true
 
 - name: Ensure Pip is installed.
-  package:
+  ansible.builtin.package:
     name: "{{ pip_package }}"
     state: present
 
+- name: Update pip to latest version.
+  ansible.builtin.pip:
+    name: pip
+    state: present
+    extra_args: --upgrade
+
 - name: Ensure pip_install_packages are installed.
-  pip:
+  ansible.builtin.pip:
     name: "{{ item.name | default(item) }}"
     version: "{{ item.version | default(omit) }}"
     virtualenv: "{{ item.virtualenv | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,8 @@
 - name: Update APT repositories.
   ansible.builtin.apt:
     update_cache: yes
-  when: ansible_facts['os_family'] == "Debian"
+  when: ansible_facts['os_family'] == "Debian" and
+        pip_sync_repospip_sync_repos is true
 
 - name: Ensure Pip is installed.
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Update APT repositories.
+  ansible.builtin.apt:
+    update_cache: yes
+  when: ansible_facts['distribution'] == "Debian"
+
 - name: Ensure Pip is installed.
   package:
     name: "{{ pip_package }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.apt:
     update_cache: yes
   when: ansible_facts['os_family'] == "Debian" and
-        pip_sync_repospip_sync_repos is true
+        pip_sync_repos is true
 
 - name: Ensure Pip is installed.
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Update APT repositories.
   ansible.builtin.apt:
     update_cache: yes
-  when: ansible_facts['distribution'] == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Ensure Pip is installed.
   package:


### PR DESCRIPTION
Some python packages expect a newer version of pip than what is shipped in most distros. So I think it would be good to upgrade it to the latest version so that isn't a problem. Possibly there should be a var to set the version?