### PR TITLE
Check major version before trying to remove externally managed.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.import_tasks: debian12.yml
   when:
     - ansible_distribution == "Debian"
-    - ansible_distribution_version == "12"
+    - ansible_distribution_major_version|int >= 12
 
 - name: Ensure Pip is installed.
   package:


### PR DESCRIPTION
Changes the variable checked from `_version` to `_major_version` in the likely chance you have an up to date Debian install on which you're running this role.

```
$ ANSIBLE_STDOUT_CALLBACK=json ansible -m setup myserver | sed '1 s/^.*$/{/' | jq '.ansible_facts.ansible_distribution_version'
"12.2"
$ ANSIBLE_STDOUT_CALLBACK=json ansible -m setup myserver | sed '1 s/^.*$/{/' | jq '.ansible_facts.ansible_distribution_major_version'
"12"
```

Minor change as well for a slight readability update.