### PR TITLE
Omit executable if item.virtualenv is defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,5 @@
     virtualenv: "{{ item.virtualenv | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
     extra_args: "{{ item.extra_args | default(omit) }}"
-    executable: "{{ pip_executable }}"
+    executable: "{{ item.virtualenv | default(false) | ternary(omit, pip_executable) }}"
   loop: "{{ pip_install_packages }}"


### PR DESCRIPTION
Fixes #55 

Implemented in this way, it shouldn't break any existing install: as it was before, when the `item.virtualenv` was defined, it didn't work because Ansible was throwing an error saying that `parameters are mutually exclusive: executable|virtualenv` (and, even if Ansible allowed it, the `executable` path would have been incorrect)