### PR TITLE
fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Remove EXTERNALLY-MANAGED
   ansible.builtin.file:
-    path: /usr/lib/python3.{{ ansible_facts.python.version.minor }}/EXTERNALLY-MANAGED
+    path: "/usr/lib/python3.{{ ansible_facts['python']['version']['minor'] }}/EXTERNALLY-MANAGED"
     state: absent
 
 - name: Ensure pip_install_packages are installed.


### PR DESCRIPTION
Hi,

this fixes:

```bash
TASK [geerlingguy.pip : Remove EXTERNALLY-MANAGED] 
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core ver
sion 2.24.
Origin: /home/ansible-dev/ansible-homeserver/roles/geerlingguy.pip/tasks/main.yml:9:11

7 - name: Remove EXTERNALLY-MANAGED
8   ansible.builtin.file:
9     path: /usr/lib/python3.{{ ansible_python.version.minor }}/EXTERNALLY-MANAGED
            ^ column 11

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```
